### PR TITLE
`--(no-)undefined-version` additions

### DIFF
--- a/lib/std/Build/Step/Compile.zig
+++ b/lib/std/Build/Step/Compile.zig
@@ -141,6 +141,9 @@ linker_dynamicbase: bool = true,
 
 linker_allow_shlib_undefined: ?bool = null,
 
+/// Allow unused version in version script (disabled by default)
+linker_allow_undefined_version: ?bool = null,
+
 /// Permit read-only relocations in read-only segments. Disallowed by default.
 link_z_notext: bool = false,
 
@@ -1737,6 +1740,9 @@ fn make(step: *Step, prog_node: *std.Progress.Node) !void {
     }
     if (self.linker_allow_shlib_undefined) |x| {
         try zig_args.append(if (x) "-fallow-shlib-undefined" else "-fno-allow-shlib-undefined");
+    }
+    if (self.linker_allow_undefined_version) |x| {
+        try zig_args.append(if (x) "--undefined-version" else "--no-undefined-version");
     }
     if (self.link_z_notext) {
         try zig_args.append("-z");

--- a/src/main.zig
+++ b/src/main.zig
@@ -1491,6 +1491,10 @@ fn buildOutputType(
                         linker_allow_shlib_undefined = true;
                     } else if (mem.eql(u8, arg, "-fno-allow-shlib-undefined")) {
                         linker_allow_shlib_undefined = false;
+                    } else if (mem.eql(u8, arg, "--undefined-version")) {
+                        linker_allow_undefined_version = true;
+                    } else if (mem.eql(u8, arg, "--no-undefined-version")) {
+                        linker_allow_undefined_version = false;
                     } else if (mem.eql(u8, arg, "-z")) {
                         const z_arg = args_iter.nextOrFatal();
                         if (mem.eql(u8, z_arg, "nodelete")) {


### PR DESCRIPTION
@behos

Fixes for https://github.com/ziglang/zig/pull/18255

- `main.zig` did not handle the option correctly, which meant that `zig build-lib --undefined-version ...` didn't actually work and instead printed an "unrecognized parameter" error message. The first commit fixes this.
- The second commit exposes the option to the build system. (I'm working on a port of SDL3 to the zig build system which needs to pass this option in order to build successfully.)

I've tested the changes locally (both the standard and `--no-` variants) and can confirm they work correctly now.